### PR TITLE
Especificar a versão

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-furo
-sphinx-design
+sphinx~=5.3.0
+furo~=2022.9.29
+sphinx-design~=0.3.0


### PR DESCRIPTION
Eu sei que parece bobagem, mas ajuda as pessoas a entenderem a importância de especificar as versões, e garante também que vai quebrar menos para quem pega esse projeto.